### PR TITLE
Fix missing apt-get install in PHP Dockerfile

### DIFF
--- a/.docker/images/php/workspace/Dockerfile
+++ b/.docker/images/php/workspace/Dockerfile
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # APT GET INIT
 ###########################################################################
 RUN apt-get update \
-    && pecl php-dev php-pear
+    && apt-get install -y --no-install-recommends php-dev php-pear
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf build-essential apt-utils zlib1g-dev libzip-dev unzip zip libpq-dev


### PR DESCRIPTION
## Summary
- fix invalid `pecl php-dev php-pear` line by installing `php-dev` and `php-pear` via apt-get

## Testing
- `shellcheck services.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840774a934083319ed0e9a5d281fbe9